### PR TITLE
Feature: generate proof for an element is contained

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all:
+build:
 	cargo build
 run:
 	cargo run

--- a/README.md
+++ b/README.md
@@ -10,5 +10,7 @@ An implementation of a merkle tree in rust with simple features
 ## ToDo's
 - [x] Create a Merkle Tree out of an array
 - [ ] Generate a proof that it contains an element
+- [ ] Change input as bytes
+- [ ] search for index
 - [ ] Verify that a given hash is contain in it
 - [ ] Can add elements once it's built

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An implementation of a merkle tree in rust with simple features
 
 ## ToDo's
 - [x] Create a Merkle Tree out of an array
-- [ ] Generate a proof that it contains an element
+- [x] Generate a proof that it contains an element
 - [ ] Change input as bytes
 - [ ] search for index
 - [ ] Verify that a given hash is contain in it

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An implementation of a merkle tree in rust with simple features
 ## ToDo's
 - [x] Create a Merkle Tree out of an array
 - [x] Generate a proof that it contains an element
-- [ ] Change input as bytes
-- [ ] search for index
+- [x] Change input as bytes
+- [x] search for index
 - [ ] Verify that a given hash is contain in it
 - [ ] Can add elements once it's built

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod merkle;
 
 fn main() {
     let data: Vec<&str> = vec!["this", "is", "a", "merkleTree"];
-    let _merkle = MerkleTree::new(&data);
+    let merkle = MerkleTree::new(&data);
+    let _proof = merkle.generate_proof(1);
     println!("hello world!");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,6 @@ mod merkle;
 fn main() {
     let data: Vec<&str> = vec!["this", "is", "a", "merkleTree"];
     let merkle = MerkleTree::new(&data);
-    let _proof = merkle.generate_proof(1);
+    let _proof = merkle.generate_proof("is");
     println!("hello world!");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,8 @@ mod merkle;
 fn main() {
     let data: Vec<&[u8]> = vec![b"this", b"is", b"a", b"merkle", b"tree"];
     let merkle = MerkleTree::new(&data);
-    let _proof = merkle.generate_proof(b"is");
+    let proof = merkle.generate_proof(b"is").unwrap();
+    let _hash = &proof[0].hash;
+    let _branch_side = &proof[0].branch_side;
     println!("hello world!");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,6 @@ mod merkle;
 
 fn main() {
     let data: Vec<&str> = vec!["this", "is", "a", "merkleTree"];
-    let _merkle = MerkleTree::new(data);
+    let _merkle = MerkleTree::new(&data);
     println!("hello world!");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,8 @@ use merkle::MerkleTree;
 mod merkle;
 
 fn main() {
-    let data: Vec<&str> = vec!["this", "is", "a", "merkleTree"];
+    let data: Vec<&[u8]> = vec![b"this", b"is", b"a", b"merkle", b"tree"];
     let merkle = MerkleTree::new(&data);
-    let _proof = merkle.generate_proof("is");
+    let _proof = merkle.generate_proof(b"is");
     println!("hello world!");
 }

--- a/src/merkle.rs
+++ b/src/merkle.rs
@@ -18,7 +18,7 @@ fn hash(value: &str) -> Hash {
 }
 
 impl MerkleTree {
-    pub fn new(data: Vec<&str>) -> MerkleTree {
+    pub fn new(data: &Vec<&str>) -> MerkleTree {
         let mut merkle = MerkleTree { tree: Vec::new() };
         if data.is_empty() {
             return merkle;
@@ -70,7 +70,7 @@ mod tests {
         ];
         let root = vec![concat_hash(&first_level[0], &first_level[1])];
 
-        let merkle = MerkleTree::new(data);
+        let merkle = MerkleTree::new(&data);
 
         // compare merkle tree has the same hashes an lengthes
         assert_eq!(leaf_hash, merkle.tree[0]);
@@ -99,7 +99,7 @@ mod tests {
         ];
         let root = vec![concat_hash(&second_level[0], &second_level[1])];
 
-        let merkle = MerkleTree::new(data);
+        let merkle = MerkleTree::new(&data);
 
         assert_eq!(leaf_hash, merkle.tree[0]);
         assert_eq!(first_level, merkle.tree[1]);


### PR DESCRIPTION
* change type of tree from string to array of bytes
* generate proof from an element, not specifying its position
* `generate_proof` return Result<Proof, ProofError>
* create `Proof` struct, contains hash and side of the branch it is included
* generate proofs of arbitrary length of the tree
* Add unit tests