### PR TITLE
Feature: verify proof if a hash is contained

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ An implementation of a merkle tree in rust with simple features
 - [x] Generate a proof that it contains an element
 - [x] Change input as bytes
 - [x] search for index
-- [ ] Verify that a given hash is contain in it
+- [x] Verify that a given hash is contain in it
 - [ ] Can add elements once it's built

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use merkle::hash;
 use merkle::MerkleTree;
 
 mod merkle;
@@ -6,8 +7,9 @@ fn main() {
     let data: Vec<&[u8]> = vec![b"this", b"is", b"a", b"merkle", b"tree"];
     let merkle = MerkleTree::new(&data);
     let proof = merkle.generate_proof(b"is").unwrap();
-    let _hashes = &proof.hashes;
-    let _root = &proof.root;
-    let _index = &proof.index;
+    let hashes = &proof.hashes;
+    let root = &proof.root;
+    let index = proof.index;
+    let _verified = merkle.verify(hashes, &hash(b"is"), root, index);
     println!("hello world!");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,8 @@ fn main() {
     let data: Vec<&[u8]> = vec![b"this", b"is", b"a", b"merkle", b"tree"];
     let merkle = MerkleTree::new(&data);
     let proof = merkle.generate_proof(b"is").unwrap();
-    let _hash = &proof[0].hash;
-    let _branch_side = &proof[0].branch_side;
+    let _hashes = &proof.hashes;
+    let _root = &proof.root;
+    let _index = &proof.index;
     println!("hello world!");
 }


### PR DESCRIPTION
* Add `verify` function to check if given a proof, element, index and a root. It can get to build the same root hash
* Add docs for functions
* Simplifies Branch directions for a index and check if even or odd to build hashes
* Add unit tests for verify